### PR TITLE
Reset connection if commit returns NOT_COORDINATOR error code

### DIFF
--- a/offsets/offsets.go
+++ b/offsets/offsets.go
@@ -5,15 +5,24 @@ import (
 	"time"
 
 	"github.com/mkocikowski/kafkaclient"
+	"github.com/mkocikowski/libkafka"
 	"github.com/mkocikowski/libkafka/client"
 )
 
 type DumbOffsetsManager struct {
-	Bootstrap string
-	GroupId   string
-	Retention time.Duration
-	client    *client.GroupClient
+	Bootstrap  string
+	GroupId    string
+	Retention  time.Duration
+	initClient func(bootstrap, group string) groupClient
+	client     groupClient
 	sync.Mutex
+}
+
+// groupClient represents interface of libkafka's GroupClient methods, and here
+// mostly for testability
+type groupClient interface {
+	FetchOffset(topic string, partition int32) (int64, error)
+	CommitOffset(topic string, partition int32, offset, retentionMs int64) error
 }
 
 func (c *DumbOffsetsManager) init() {
@@ -22,10 +31,14 @@ func (c *DumbOffsetsManager) init() {
 	if c.client != nil {
 		return
 	}
-	c.client = &client.GroupClient{
-		Bootstrap: c.Bootstrap,
-		GroupId:   c.GroupId,
+	if c.initClient == nil {
+		c.client = &client.GroupClient{
+			Bootstrap: c.Bootstrap,
+			GroupId:   c.GroupId,
+		}
+		return
 	}
+	c.client = c.initClient(c.Bootstrap, c.GroupId)
 }
 
 func (c *DumbOffsetsManager) Fetch(topic string, partition int32) (int64, error) {
@@ -42,12 +55,29 @@ func (c *DumbOffsetsManager) Fetch(topic string, partition int32) (int64, error)
 	return offset, err
 }
 
-func (c DumbOffsetsManager) Commit(topic string, partition int32, offset int64) error {
+// Commit sends CommitOffset API request to Kafka, which sets offset for a
+// specific partition. If the response of API call has NOT_COORDINATOR error
+// code, request will be retried after reconnecting to Kafka. NOT_COORDINATOR
+// error happens when coordinator for the current group was re-assigned by some
+// reasons and client is trying to use "old/inactive". In this case client
+// should re-discover new coordinator and continue communication.
+func (c *DumbOffsetsManager) Commit(topic string, partition int32, offset int64) error {
 	c.init() // idempotent
 	err := c.client.CommitOffset(topic, partition, offset, -1)
 	if err != nil {
-		err = kafkaclient.Errorf("error for topic %s partition %d: %w",
+		returnErr := kafkaclient.Errorf("error for topic %s partition %d: %w",
 			topic, partition, err)
+
+		libkafkaError, ok := err.(*libkafka.Error)
+		if !ok {
+			return returnErr
+		}
+		if libkafkaError.Code == libkafka.ERR_NOT_COORDINATOR {
+			c.Lock()
+			c.client = nil
+			c.Unlock()
+		}
+		return returnErr
 	}
-	return err
+	return nil
 }

--- a/offsets/offsets_test.go
+++ b/offsets/offsets_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"strings"
 	"testing"
 	"time"
 
@@ -60,5 +61,79 @@ func TestIntegrationOffsets(t *testing.T) {
 	}
 	if offset != 100 {
 		t.Fatal(offset)
+	}
+}
+
+type dummyGroupClient struct {
+	offset            int64
+	commitOffsetError error
+}
+
+func (d *dummyGroupClient) FetchOffset(topic string, partition int32) (int64, error) {
+	return d.offset, nil
+}
+func (d *dummyGroupClient) CommitOffset(topic string, partition int32, offset, retentionMs int64) error {
+	return d.commitOffsetError
+}
+
+func TestUnitCommitOffet(t *testing.T) {
+	cl := &dummyGroupClient{}
+
+	initClient := func(bootstrap, group string) groupClient {
+		return &dummyGroupClient{}
+	}
+
+	om := &DumbOffsetsManager{
+		client:     cl,
+		initClient: initClient,
+	}
+
+	cl.commitOffsetError = &libkafka.Error{
+		Code: libkafka.ERR_BROKER_NOT_AVAILABLE,
+	}
+	// we should get error as is
+	e := om.Commit("topic", 0, 1)
+	if e == nil {
+		t.Fatal("we didn't get expected error")
+	}
+	if !strings.HasSuffix(e.Error(), "(BROKER_NOT_AVAILABLE)") {
+		t.Fatalf("we got unexpected error: %v", e)
+	}
+
+	// we should get error as is
+	cl.commitOffsetError = fmt.Errorf("some sort of error")
+	e = om.Commit("topic", 0, 1)
+	if e == nil {
+		t.Fatal("we didn't get expected error")
+	}
+	if !strings.HasSuffix(e.Error(), "some sort of error") {
+		t.Fatalf("we got unexpected error: %v", e)
+	}
+
+	// clean commit, no error
+	cl.commitOffsetError = nil
+	e = om.Commit("topic", 0, 1)
+	if e != nil {
+		t.Fatalf("we got unexpected error: %v", e)
+	}
+
+	// coordinator was re-assigned, we should see this in error, next commit
+	// should be okay
+	cl.commitOffsetError = &libkafka.Error{
+		Code: libkafka.ERR_NOT_COORDINATOR,
+	}
+	e = om.Commit("topic", 0, 1)
+	if e == nil {
+		t.Fatal("we didn't get expected error")
+	}
+	if !strings.HasSuffix(e.Error(), "(NOT_COORDINATOR)") {
+		t.Fatalf("we got unexpected error: %v", e)
+	}
+	if om.client != nil {
+		t.Fatal("client should be reset")
+	}
+	e = om.Commit("topic", 0, 1)
+	if e != nil {
+		t.Fatalf("we got unexpected error: %v", e)
 	}
 }


### PR DESCRIPTION
This commit updates `kafkaclient` in order to correctly react when
the group's coordinator get re-assigned.

It happens, that for some reasons, Group's coordinator can be
re-assigned without notifying the client. In that case, every
client should discover new coordinator and continue communication
with the new one. The change proposed in the commit detects that
the coordinator was changed and drops the connection. However, error
NOT_COORDINATOR will be returned but the next attempt to commit
offsets will start with discovering the new Coordinator.