### PR TITLE
Add CommitAll() method to commit offsets for a set of partitions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,5 @@
 module github.com/mkocikowski/kafkaclient
 
-go 1.13
+go 1.17
 
-require github.com/mkocikowski/libkafka v0.0.29
-
-//replace github.com/mkocikowski/libkafka => /home/mik/src/github.com/mkocikowski/libkafka
+require github.com/mkocikowski/libkafka v0.0.30

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/mkocikowski/libkafka v0.0.29 h1:QbTh6ssppZVhxL8vPsmFaW+KbONwER0POzj1CdtCpp0=
-github.com/mkocikowski/libkafka v0.0.29/go.mod h1:yq/tp+9lNspzf75zi3aFJbXjUlFuduwHgXLKugyMCew=
+github.com/mkocikowski/libkafka v0.0.30 h1:9FeWyF2Q1hVff2RHBJFn3JsvJ1EKv+4vcJQ12aqG3r8=
+github.com/mkocikowski/libkafka v0.0.30/go.mod h1:yq/tp+9lNspzf75zi3aFJbXjUlFuduwHgXLKugyMCew=


### PR DESCRIPTION
This commit updates libkafka and brings the use of CommitOffsets()
method to DumbOffsetsManager.

This method provides a bulk update of offsets for multiple partitions.
Golang version in go.mod was updated to 1.17.

-----
This PR will be updated after https://github.com/mkocikowski/libkafka/pull/17
gets merged.